### PR TITLE
merge latest into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 This extension provides capabilities for the IBM [developer cli](https://console.ng.bluemix.net/docs/cloudnative/dev_cli.html) from directly within the VS Code editor.   Use the VS Code command palette to quickly access all `bx dev` commands, without the need to leave the editor's context.
 
 ## Changelog
+- *v0.0.12* 
+  - Added support for `bx dev shell` command
+  - Removed support for the `sdkgen` cli
+  - Improved cli version detection with minimum versioning and forced upgrade paths to support new cli features
+  - Added support for "caller" arguments for the `dev` cli
 - *v0.0.11* 
   - Added support for Kubernetes/Helm deployment
   - Added support for `bx dev console`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 This extension provides capabilities for the IBM [developer cli](https://console.ng.bluemix.net/docs/cloudnative/dev_cli.html) from directly within the VS Code editor.   Use the VS Code command palette to quickly access all `bx dev` commands, without the need to leave the editor's context.
 
 ## Changelog
+- *v0.0.11* 
+  - Added support for Kubernetes/Helm deployment
+  - Added support for `bx dev console`
 - *v0.0.10* 
   - Updated badges in README for VS Code marketplace compliance.  
   - Fixed "killed terminal" bug in login/logout commands

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-developer",
   "displayName": "IBM Developer Tools",
   "description": "Extension for VS Code editor to enable IBM Bluemix developer `bx dev` CLI capabilities from within the editing environment.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "publisher": "IBM",
   "license": "Apache 2.0 (see LICENSE.txt)",
   "bugs": {
@@ -37,6 +37,8 @@
     "onCommand:extension.bx.dev.build",
     "onCommand:extension.bx.dev.debug",
     "onCommand:extension.bx.dev.deploy",
+    "onCommand:extension.bx.dev.deploy.cloudfoundry",
+    "onCommand:extension.bx.dev.deploy.kubernetes",
     "onCommand:extension.bx.dev.run",
     "onCommand:extension.bx.dev.status",
     "onCommand:extension.bx.dev.stop",
@@ -100,7 +102,15 @@
       },
       {
         "command": "extension.bx.dev.deploy",
-        "title": "bx dev deploy"
+        "title": "bx dev deploy    (using cli-config values)"
+      },
+      {
+        "command": "extension.bx.dev.deploy.cloudfoundry",
+        "title": "bx dev deploy    (explicit Cloud Foundry deployment)"
+      },
+      {
+        "command": "extension.bx.dev.deploy.kubernetes",
+        "title": "bx dev deploy    (explicity Kubernetes deployment)"
       },
       {
         "command": "extension.bx.dev.build",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "onCommand:extension.bx.dev.debug",
     "onCommand:extension.bx.dev.deploy",
     "onCommand:extension.bx.dev.run",
+    "onCommand:extension.bx.dev.shell.run",
+    "onCommand:extension.bx.dev.shell.tools",
     "onCommand:extension.bx.dev.status",
     "onCommand:extension.bx.dev.stop",
     "onCommand:extension.bx.dev.test",
@@ -66,7 +68,7 @@
     "onCommand:extension.bx.cs.worker-reboot",
     "onCommand:extension.bx.cs.worker-reload",
     "onCommand:extension.bx.cs.worker-rm",
-    "onCommand:extension.bx.cs.workers",
+    "onCommand:extension.bx.cs.workers"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -274,7 +276,7 @@
       {
         "displayName": "dev",
         "command": "dev",
-        "version": "1.0.5",
+        "version": "1.1.0",
         "url": "https://console.ng.bluemix.net/docs/cloudnative/dev_cli.html"
       },
       {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "publisher": "IBM",
   "license": "Apache 2.0 (see LICENSE.txt)",
   "bugs": {
-      "url": "https://github.com/IBM-Bluemix/ibm-developer-extension-vscode/issues"
+    "url": "https://github.com/IBM-Bluemix/ibm-developer-extension-vscode/issues"
   },
   "homepage": "https://github.com/IBM-Bluemix/ibm-developer-extension-vscode/blob/master/README.md",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/IBM-Bluemix/ibm-developer-extension-vscode.git"
+    "type": "git",
+    "url": "https://github.com/IBM-Bluemix/ibm-developer-extension-vscode.git"
   },
   "engines": {
     "vscode": "^1.10.0"
@@ -37,8 +37,6 @@
     "onCommand:extension.bx.dev.build",
     "onCommand:extension.bx.dev.debug",
     "onCommand:extension.bx.dev.deploy",
-    "onCommand:extension.bx.dev.deploy.cloudfoundry",
-    "onCommand:extension.bx.dev.deploy.kubernetes",
     "onCommand:extension.bx.dev.run",
     "onCommand:extension.bx.dev.status",
     "onCommand:extension.bx.dev.stop",
@@ -102,15 +100,7 @@
       },
       {
         "command": "extension.bx.dev.deploy",
-        "title": "bx dev deploy    (using cli-config values)"
-      },
-      {
-        "command": "extension.bx.dev.deploy.cloudfoundry",
-        "title": "bx dev deploy    (explicit Cloud Foundry deployment)"
-      },
-      {
-        "command": "extension.bx.dev.deploy.kubernetes",
-        "title": "bx dev deploy    (explicit Kubernetes deployment)"
+        "title": "bx dev deploy"
       },
       {
         "command": "extension.bx.dev.build",
@@ -273,6 +263,7 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
+    "js-yaml": "^3.9.1",
     "ps-tree": "^1.1.0",
     "semver": "^5.3.0"
   },
@@ -283,24 +274,28 @@
   "ibm": {
     "cli": {
       "command": "bx",
-      "version": "0.5.3",
+      "version": "0.5.6",
       "url": "https://console.ng.bluemix.net/docs/cli/reference/bluemix_cli/index.html#getting-started"
     },
-    "plugins": [{
-      "displayName": "dev",
-      "command": "dev",
-      "version": "0.1.5",
-      "url": "https://console.ng.bluemix.net/docs/cloudnative/dev_cli.html"
-    },{
-      "displayName": "sdk-gen",
-      "command": "sdk",
-      "version": "0.1.1",
-      "url": "https://console.ng.bluemix.net/docs/cloudnative/sdk_cli.html#sdk-cli"
-    },{
-      "displayName": "container-service",
-      "command": "cs",
-      "version": "0.1.259",
-      "url": "https://console.ng.bluemix.net/docs/containers/cs_cli_devtools.html"
-    }]
+    "plugins": [
+      {
+        "displayName": "dev",
+        "command": "dev",
+        "version": "1.0.0",
+        "url": "https://console.ng.bluemix.net/docs/cloudnative/dev_cli.html"
+      },
+      {
+        "displayName": "sdk-gen",
+        "command": "sdk",
+        "version": "0.1.1",
+        "url": "https://console.ng.bluemix.net/docs/cloudnative/sdk_cli.html#sdk-cli"
+      },
+      {
+        "displayName": "container-service",
+        "command": "cs",
+        "version": "0.1.259",
+        "url": "https://console.ng.bluemix.net/docs/containers/cs_cli_devtools.html"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-developer",
   "displayName": "IBM Developer Tools",
   "description": "Extension for VS Code editor to enable IBM Bluemix developer `bx dev` CLI capabilities from within the editing environment.",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "publisher": "IBM",
   "license": "Apache 2.0 (see LICENSE.txt)",
   "bugs": {
@@ -67,9 +67,6 @@
     "onCommand:extension.bx.cs.worker-reload",
     "onCommand:extension.bx.cs.worker-rm",
     "onCommand:extension.bx.cs.workers",
-    "onCommand:extension.bx.sdk.list",
-    "onCommand:extension.bx.sdk.generate",
-    "onCommand:extension.bx.sdk.validate"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -279,12 +276,6 @@
         "command": "dev",
         "version": "1.0.5",
         "url": "https://console.ng.bluemix.net/docs/cloudnative/dev_cli.html"
-      },
-      {
-        "displayName": "sdk-gen",
-        "command": "sdk",
-        "version": "0.1.1",
-        "url": "https://console.ng.bluemix.net/docs/cloudnative/sdk_cli.html#sdk-cli"
       },
       {
         "displayName": "container-service",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
       },
       {
         "command": "extension.bx.dev.deploy.kubernetes",
-        "title": "bx dev deploy    (explicity Kubernetes deployment)"
+        "title": "bx dev deploy    (explicit Kubernetes deployment)"
       },
       {
         "command": "extension.bx.dev.build",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,8 @@ export function activate(context: ExtensionContext) {
     registerCommand(context, 'extension.bx.dev.build.release', {cmd: 'bx', args: ['dev', 'build']}, outputChannel, true);
     registerCommand(context, 'extension.bx.dev.debug', {cmd: 'bx', args: ['dev', 'debug']}, outputChannel);
     registerCommand(context, 'extension.bx.dev.deploy', {cmd: 'bx', args: ['dev', 'deploy']}, outputChannel);
+    registerCommand(context, 'extension.bx.dev.deploy.cloudfoundry', {cmd: 'bx', args: ['dev', 'deploy', '--target', 'buildpack', '--trace']}, outputChannel);
+    registerCommand(context, 'extension.bx.dev.deploy.kubernetes', {cmd: 'bx', args: ['dev', 'deploy', '--target', 'container', '--trace']}, outputChannel);
     registerCommand(context, 'extension.bx.dev.run', {cmd: 'bx', args: ['dev', 'run']}, outputChannel);
     registerCommand(context, 'extension.bx.dev.status', {cmd: 'bx', args: ['dev', 'status']}, outputChannel);
     registerCommand(context, 'extension.bx.dev.stop', {cmd: 'bx', args: ['dev', 'stop']}, outputChannel);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@
 
 import {commands, window, ExtensionContext} from 'vscode';
 import {LogsCommandManager} from './cloudfoundry/LogsCommandManager';
+import {DeployCommand} from './util/DeployCommand';
 import {LoginManager} from './util/LoginManager';
 import {PromptingCommand, PromptInput} from './util/PromptingCommand';
 import {SystemCommand} from './util/SystemCommand';
@@ -47,9 +48,7 @@ export function activate(context: ExtensionContext) {
     registerCommand(context, 'extension.bx.dev.build', {cmd: 'bx', args: ['dev', 'build', '--debug']}, outputChannel, true);
     registerCommand(context, 'extension.bx.dev.build.release', {cmd: 'bx', args: ['dev', 'build']}, outputChannel, true);
     registerCommand(context, 'extension.bx.dev.debug', {cmd: 'bx', args: ['dev', 'debug']}, outputChannel);
-    registerCommand(context, 'extension.bx.dev.deploy', {cmd: 'bx', args: ['dev', 'deploy']}, outputChannel);
-    registerCommand(context, 'extension.bx.dev.deploy.cloudfoundry', {cmd: 'bx', args: ['dev', 'deploy', '--target', 'buildpack', '--trace']}, outputChannel);
-    registerCommand(context, 'extension.bx.dev.deploy.kubernetes', {cmd: 'bx', args: ['dev', 'deploy', '--target', 'container', '--trace']}, outputChannel);
+    registerCommand(context, 'extension.bx.dev.deploy', {cmd: 'bx', args: ['dev', 'deploy', '--trace']}, outputChannel, false, DeployCommand);
     registerCommand(context, 'extension.bx.dev.run', {cmd: 'bx', args: ['dev', 'run']}, outputChannel);
     registerCommand(context, 'extension.bx.dev.status', {cmd: 'bx', args: ['dev', 'status']}, outputChannel);
     registerCommand(context, 'extension.bx.dev.stop', {cmd: 'bx', args: ['dev', 'stop']}, outputChannel);
@@ -101,9 +100,9 @@ export function activate(context: ExtensionContext) {
 /*
  *  Helper utility to register system commands
  */
-function registerCommand(context: ExtensionContext, key: string, opt, outputChannel, sanitizeOutput: boolean = false) {
+function registerCommand(context: ExtensionContext, key: string, opt, outputChannel, sanitizeOutput: boolean = false, CommandClass = SystemCommand) {
     const disposable = commands.registerCommand(key, () => {
-        const command = new SystemCommand(opt.cmd, opt.args, outputChannel, sanitizeOutput);
+        const command = new CommandClass(opt.cmd, opt.args, outputChannel, sanitizeOutput);
         command.execute()
         .then(checkVersions);
     });

--- a/src/util/DeployCommand.ts
+++ b/src/util/DeployCommand.ts
@@ -61,7 +61,7 @@ export class DeployCommand extends SystemCommand {
                 }
             }
         }
-        else if (deployTarget !== 'buildpack') {
+        else if (deployTarget !== 'buildpack' && (deployTarget !== '' && deployTarget !== undefined)) {
             return new Promise((resolve, reject) => {
                 this.displayError('Invalid \'deploy-target\' value in cli-config.yml.');
             });

--- a/src/util/DeployCommand.ts
+++ b/src/util/DeployCommand.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corporation 2016, 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+'use strict';
+
+import {window, workspace} from 'vscode';
+import {SystemCommand} from './SystemCommand';
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+/*
+ * Class for invoking system commands with prompt(s) for input
+ */
+export class DeployCommand extends SystemCommand {
+
+    /*
+     * Validate cli-config and then execute the deploy command
+     */
+    execute(): Promise<any> {
+        const targetFile = workspace.rootPath + '/cli-config.yml';
+
+        if (!fs.existsSync(targetFile)) {
+            return new Promise((resolve, reject) => {
+                this.displayError('Could not find file cli-config.yml in project root.  Aborting deployment.');
+            });
+        }
+
+        const yml = yaml.safeLoad(fs.readFileSync(targetFile, 'utf8'));
+
+        // if deploy target is "container", validate the deploy-imate-target and ibm-cluster values
+        const deployTarget = yml['deploy-target'];
+        if (deployTarget === 'container') {
+
+            const deployImageTarget = yml['deploy-image-target'];
+            if (deployImageTarget === undefined || deployImageTarget === '') {
+                return new Promise((resolve, reject) => {
+                    this.displayError('Please specify \'deploy-image-target\' in cli-config.yml for Kubernetes deployment.');
+                });
+            } else {
+                const regex = new RegExp(/registry.*.bluemix.net/);
+                if (regex.test(deployImageTarget)) {
+                    const cluster = yml['ibm-cluster'];
+                    if (cluster === undefined || cluster === '') {
+                        return new Promise((resolve, reject) => {
+                            this.displayError('Please specify \'ibm-cluster\' in cli-config.yml for Kubernetes deployment targeting IBM Cloud.');
+                        });
+                    }
+                }
+            }
+        }
+        else if (deployTarget !== 'buildpack') {
+            return new Promise((resolve, reject) => {
+                this.displayError('Invalid \'deploy-target\' value in cli-config.yml.');
+            });
+        }
+        return super.execute();
+    }
+
+    /*
+     * display error message
+     */
+    displayError(message: string) {
+        this.output(`\nERROR: ${message}`);
+        window.showErrorMessage(message);
+    }
+}


### PR DESCRIPTION
- *v0.0.12* 
  - Added support for `bx dev shell` command
  - Removed support for the `sdkgen` cli
  - Improved cli version detection with minimum versioning and forced upgrade paths to support new cli features
  - Added support for "caller" arguments for the `dev` cli