### PR TITLE
build: Added missing vsce install in script

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -3,8 +3,8 @@
 set -e
 
 # Install vsce if not in PATH
-if [[ -z $(command -v vsce) ]];
-  npm install -g
+if [[ -z $(command -v vsce) ]]; then
+  npm install -g vsce
 fi
 
 vsce publish


### PR DESCRIPTION
I made an error and forgot some important parts to the script. Unfortunately there is no dry run option for me to test. I tested it by commenting out the `vsce publish` line. 